### PR TITLE
unmap map_base after each iteration to prevent memory leak

### DIFF
--- a/gddr6.c
+++ b/gddr6.c
@@ -183,6 +183,9 @@ int main(int argc, char **argv)
             temp = ((read_result & 0x00000fff) / 0x20);
 
             printf(" %3u°c |", temp);
+
+            // unmap that offset, allows the same virtual address to be reused each iteration
+            munmap(map_base, PG_SZ);
         }
         fflush(stdout);
         sleep(1);


### PR DESCRIPTION
without calling munmap after each iteration, the virtual address for map_base changes on each iteration. Adding this unmap call allows the same address for map_base for each iteration.