### PR TITLE
Add RTX A4500 + L4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,7 @@ cd gddr6 && make && sudo ./gddr6
 - RTX 3070 (GA104)
 - RTX 3070 LHR (GA104)
 - RTX A2000 (GA106)
+- RTX A4500 (GA102)
+- L4 (AD104)
 
 ![](https://github.com/olealgoritme/gddr6/blob/master/gddr6_use.gif)

--- a/gddr6.c
+++ b/gddr6.c
@@ -54,6 +54,8 @@ struct device dev_table[] =
     { .offset = 0x0000EE50, .dev_id = 0x2488, .vram = "GDDR6",  .arch = "GA104", .name =  "RTX 3070 LHR" },
     { .offset = 0x0000E2A8, .dev_id = 0x2531, .vram = "GDDR6",  .arch = "GA106", .name =  "RTX A2000" },
     { .offset = 0x0000E2A8, .dev_id = 0x2571, .vram = "GDDR6",  .arch = "GA106", .name =  "RTX A2000" },
+    { .offset = 0x0000E2A8, .dev_id = 0x2232, .vram = "GDDR6",  .arch = "GA102", .name =  "RTX A4500" },
+    { .offset = 0x0000E2A8, .dev_id = 0x27b8, .vram = "GDDR6",  .arch = "AD104", .name =  "L4" },
 };
 
 


### PR DESCRIPTION
Hi,

Adding support for the RTX A4500:

```
Device: RTX A4500 GDDR6 (GA102 / 0x2232) pci=c4:0:0
VRAM Temps: |  38°c | 
```

And for the L4:

```
Device: L4 GDDR6 (AD104 / 0x27b8) pci=1:0:0
VRAM Temps: |  44°c | 
```

The temperature are properly increasing under load as well.

Thanks !