### PR TITLE
Correct symbol for degrees Celsius

### DIFF
--- a/gddr6.c
+++ b/gddr6.c
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
             read_result = *((uint32_t *) virt_addr);
             temp = ((read_result & 0x00000fff) / 0x20);
 
-            printf(" %3u°c |", temp);
+            printf(" %3u°C |", temp);
         }
         fflush(stdout);
         sleep(1);


### PR DESCRIPTION
The output was reading "°c", which is ever so slightly incorrect, because it is supposed to be a capital "C". So, I fixed it in the only commit of this pull request. See also:

https://en.wikipedia.org/wiki/Celsius