### PR TITLE
Add L40S support

### DIFF
--- a/gddr6.c
+++ b/gddr6.c
@@ -56,6 +56,7 @@ struct device dev_table[] =
     { .offset = 0x0000E2A8, .dev_id = 0x2571, .vram = "GDDR6",  .arch = "GA106", .name =  "RTX A2000" },
     { .offset = 0x0000E2A8, .dev_id = 0x2232, .vram = "GDDR6",  .arch = "GA102", .name =  "RTX A4500" },
     { .offset = 0x0000E2A8, .dev_id = 0x27b8, .vram = "GDDR6",  .arch = "AD104", .name =  "L4" },
+    { .offset = 0x0000E2A8, .dev_id = 0x26b9, .vram = "GDDR6",  .arch = "AD102", .name =  "L40S" },
 };
 
 


### PR DESCRIPTION
Seems to work like a charm:

```
root@rescue:~# ./gddr6 
Device: L40S GDDR6 (AD102 / 0x26b9) pci=21:0:0
Device: L40S GDDR6 (AD102 / 0x26b9) pci=a1:0:0
Device: L40S GDDR6 (AD102 / 0x26b9) pci=41:0:0
Device: L40S GDDR6 (AD102 / 0x26b9) pci=c1:0:0
VRAM Temps: |  46°c |  46°c |  48°c |  46°c |
```