### PR TITLE
Add A10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,7 @@ cd gddr6 && make && sudo ./gddr6
 - RTX A2000 (GA106)
 - RTX A4500 (GA102)
 - L4 (AD104)
+- L40S (AD102)
+- A10 (GA102)
 
 ![](https://github.com/olealgoritme/gddr6/blob/master/gddr6_use.gif)

--- a/gddr6.c
+++ b/gddr6.c
@@ -57,6 +57,7 @@ struct device dev_table[] =
     { .offset = 0x0000E2A8, .dev_id = 0x2232, .vram = "GDDR6",  .arch = "GA102", .name =  "RTX A4500" },
     { .offset = 0x0000E2A8, .dev_id = 0x27b8, .vram = "GDDR6",  .arch = "AD104", .name =  "L4" },
     { .offset = 0x0000E2A8, .dev_id = 0x26b9, .vram = "GDDR6",  .arch = "AD102", .name =  "L40S" },
+    { .offset = 0x0000E2A8, .dev_id = 0x2236, .vram = "GDDR6",  .arch = "GA102", .name =  "A10" },
 };
 
 


### PR DESCRIPTION
```
Device: A10 GDDR6 (GA102 / 0x2236) pci=c4:0:0
Device: A10 GDDR6 (GA102 / 0x2236) pci=81:0:0
Device: A10 GDDR6 (GA102 / 0x2236) pci=41:0:0
Device: A10 GDDR6 (GA102 / 0x2236) pci=82:0:0
VRAM Temps: |  52°c |  46°c |  50°c |  46°c |
```