### PR TITLE
Update gddr6.c to add RTX A5000

### DIFF
--- a/gddr6.c
+++ b/gddr6.c
@@ -42,6 +42,7 @@ struct device devices[32];
 struct device dev_table[] =
 {
     { .offset = 0x0000E2A8, .dev_id = 0x26B1, .vram = "GDDR6",  .arch = "AD102", .name =  "RTX A6000" },
+    { .offset = 0x0000E2A8, .dev_id = 0x2231, .vram = "GDDR6", .arch = "GA102", .name =  "RTX A5000" },
     { .offset = 0x0000E2A8, .dev_id = 0x2684, .vram = "GDDR6X", .arch = "AD102", .name =  "RTX 4090" },
     { .offset = 0x0000E2A8, .dev_id = 0x2704, .vram = "GDDR6X", .arch = "AD103", .name =  "RTX 4080" },
     { .offset = 0x0000E2A8, .dev_id = 0x2782, .vram = "GDDR6X", .arch = "AD104", .name =  "RTX 4070 Ti" },


### PR DESCRIPTION
seems to work with the common E2A8 offset