### PR TITLE
Fix ctx.devices segfault, add flake.nix, add rtx 4070 mobile support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Linux based GDDR6/GDDR6X VRAM temperature reader for NVIDIA RTX 3000/4000 series GPUs.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+  utils.lib.eachDefaultSystem(system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      packages.gddr6 = with pkgs; stdenv.mkDerivation {
+        pname = "gddr6";
+        version = "unstable";
+
+        src = ./.;
+
+        buildInputs = [ cmake ];
+        nativeBuildInputs = [ pciutils ];
+      };
+
+      packages.default = self.packages.${system}.gddr6;
+
+      devShell = with pkgs; mkShell {
+        name = "gddr6";
+        nativeBuildInputs = [ cmake pciutils ];
+      };
+    }
+  );
+}
+

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -85,11 +85,11 @@ int gddr6_detect_compatible_gpus(void)
                   }
                   ctx.devices = new_devices;
 
-                  ctx.devices[i] = dev_table[i];
-                  ctx.devices[i].bar0 = (pci_dev->base_addr[0] & 0xffffffff);
-                  ctx.devices[i].bus = pci_dev->bus;
-                  ctx.devices[i].dev = pci_dev->dev;
-                  ctx.devices[i].func = pci_dev->func;
+                  ctx.devices[ctx.num_devices] = dev_table[i];
+                  ctx.devices[ctx.num_devices].bar0 = (pci_dev->base_addr[0] & 0xffffffff);
+                  ctx.devices[ctx.num_devices].bus = pci_dev->bus;
+                  ctx.devices[ctx.num_devices].dev = pci_dev->dev;
+                  ctx.devices[ctx.num_devices].func = pci_dev->func;
                   ctx.num_devices++;
               }
           }

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -29,6 +29,7 @@ struct device dev_table[] =
     { .offset = 0x0000E2A8, .dev_id = 0x2704, .vram = "GDDR6X", .arch = "AD103", .name =  "RTX 4080" },
     { .offset = 0x0000E2A8, .dev_id = 0x2782, .vram = "GDDR6X", .arch = "AD104", .name =  "RTX 4070 Ti" },
     { .offset = 0x0000E2A8, .dev_id = 0x2786, .vram = "GDDR6X", .arch = "AD104", .name =  "RTX 4070" },
+    { .offset = 0x0000E2A8, .dev_id = 0x2860, .vram = "GDDR6",  .arch = "AD106", .name =  "RTX 4070 Max-Q / Mobile" },
     { .offset = 0x0000E2A8, .dev_id = 0x2204, .vram = "GDDR6X", .arch = "GA102", .name =  "RTX 3090" },
     { .offset = 0x0000E2A8, .dev_id = 0x2208, .vram = "GDDR6X", .arch = "GA102", .name =  "RTX 3080 Ti" },
     { .offset = 0x0000E2A8, .dev_id = 0x2206, .vram = "GDDR6X", .arch = "GA102", .name =  "RTX 3080" },


### PR DESCRIPTION
Fixes segfault caused by using wrong variable `i` as index for `ctx.devices`
Adds simple `flake.nix` for building with Nix package manager
Adds support for RTX 4070 Max-Q / Mobile which uses common E2A8 offset and GDDR6 memory  