### PR TITLE
JSON output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ cd gddr6
 sudo gddr6
 ```
 
+## Running
+```
+sudo gddr6       # for human-readable monitoring
+sudo gddr6 -j    # for one-time JSON output
+```
+
 ## Supported GPUs
 - RTX 4090 (AD102)
 - RTX 4080 Super (AD103)

--- a/app/src/app.c
+++ b/app/src/app.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    gddr6_memory_map(0);
+    gddr6_memory_map();
 
     if (argc >= 2 && !strcmp(argv[1], "-j"))
     {

--- a/app/src/app.c
+++ b/app/src/app.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
+#include <string.h>
 
 void register_signal_handlers(void)
 {
@@ -24,12 +25,20 @@ int main(int argc, char **argv)
 
     if (num_devs == 0)
     {
-        printf("No compatible GPU found.\n");
+        fprintf(stderr, "No compatible GPU found.\n");
         return 1;
     }
 
-    gddr6_memory_map();
-    gddr6_monitor_temperatures();
+    if (argc >= 2 && !strcmp(argv[1], "-j"))
+    {
+        gddr6_memory_map(0);
+        gddr6_print_temperatures_json();
+    }
+    else
+    {
+        gddr6_memory_map(1);            
+        gddr6_monitor_temperatures();
+    }
 
     return 0;
 }

--- a/app/src/app.c
+++ b/app/src/app.c
@@ -37,7 +37,6 @@ int main(int argc, char **argv)
     }
     else
     {
-        gddr6_print_memory_map();
         gddr6_monitor_temperatures();
     }
 

--- a/app/src/app.c
+++ b/app/src/app.c
@@ -29,14 +29,15 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    gddr6_memory_map(0);
+
     if (argc >= 2 && !strcmp(argv[1], "-j"))
     {
-        gddr6_memory_map(0);
         gddr6_print_temperatures_json();
     }
     else
     {
-        gddr6_memory_map(1);            
+        gddr6_print_memory_map();
         gddr6_monitor_temperatures();
     }
 

--- a/lib/include/gddr6.h
+++ b/lib/include/gddr6.h
@@ -22,12 +22,15 @@ struct gddr6_ctx {
   struct device *devices;
   int num_devices;
   int fd;
+  uint32_t *temperatures;
 };
 
 void gddr6_init(void);
-void gddr6_memory_map(void);
+void gddr6_memory_map(int verbose);
 void gddr6_cleanup(int signal);
+void gddr6_get_temperatures(void);
 void gddr6_monitor_temperatures(void);
+void gddr6_print_temperatures_json(void);
 int gddr6_detect_compatible_gpus(void);
 
 #endif // GDDR6_H

--- a/lib/include/gddr6.h
+++ b/lib/include/gddr6.h
@@ -26,7 +26,8 @@ struct gddr6_ctx {
 };
 
 void gddr6_init(void);
-void gddr6_memory_map(int verbose);
+void gddr6_memory_map();
+void gddr6_print_memory_map();
 void gddr6_cleanup(int signal);
 void gddr6_get_temperatures(void);
 void gddr6_monitor_temperatures(void);

--- a/lib/include/gddr6.h
+++ b/lib/include/gddr6.h
@@ -26,8 +26,8 @@ struct gddr6_ctx {
 };
 
 void gddr6_init(void);
-void gddr6_memory_map();
-void gddr6_print_memory_map();
+void gddr6_memory_map(void);
+void gddr6_print_memory_map(void);
 void gddr6_cleanup(int signal);
 void gddr6_get_temperatures(void);
 void gddr6_monitor_temperatures(void);

--- a/lib/include/gddr6.h
+++ b/lib/include/gddr6.h
@@ -22,7 +22,7 @@ struct gddr6_ctx {
   struct device *devices;
   int num_devices;
   int fd;
-  uint32_t *temperatures;
+  int32_t *temperatures;
 };
 
 void gddr6_init(void);

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -120,14 +120,14 @@ void gddr6_memory_map(int verbose)
         if (ctx.devices[i].mapped_addr == MAP_FAILED)
         {
             ctx.devices[i].mapped_addr = NULL;
-            fprintf(stderr, "Memory mapping failed for pci=%x:%x:%x\n", ctx.devices[i].bus, ctx.devices[i].dev, ctx.devices[i].func);
+            fprintf(stderr, "Memory mapping failed for pci=%02X:%02X.%X\n", ctx.devices[i].bus, ctx.devices[i].dev, ctx.devices[i].func);
             fprintf(stderr, "Did you enable iomem=relaxed? Are you r00t?\n");
             exit(EXIT_FAILURE);
         }
 
         if (verbose)
         {
-            printf("Device: %s %s (%s / 0x%04x) pci=%02x:%02x:%02x\n", ctx.devices[i].name, ctx.devices[i].vram,
+            printf("Device: %s %s (%s / 0x%04x) pci=%02X:%02X.%X\n", ctx.devices[i].name, ctx.devices[i].vram,
             ctx.devices[i].arch, ctx.devices[i].dev_id, ctx.devices[i].bus, ctx.devices[i].dev, ctx.devices[i].func);
         }
     }
@@ -181,7 +181,7 @@ void gddr6_print_temperatures_json(void)
     {
         char *delimiter = i < ctx.num_devices - 1 ? "," : "";
         printf(
-            "  {\"name\": \"%s\", \"vram\": \"%s\", \"arch\": \"%s\", \"dev_id\": \"0x%04x\", \"pci_id\": \"%02x:%02x:%02x\", \"temp\": %d}%s\n",
+            "  {\"name\": \"%s\", \"vram\": \"%s\", \"arch\": \"%s\", \"dev_id\": \"0x%04x\", \"pci_id\": \"%02X:%02X:%X\", \"temp\": %d}%s\n",
             ctx.devices[i].name, ctx.devices[i].vram, ctx.devices[i].arch, ctx.devices[i].dev_id, ctx.devices[i].bus, ctx.devices[i].dev,
             ctx.devices[i].func, ctx.temperatures[i], delimiter
         );

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -181,9 +181,9 @@ void gddr6_print_temperatures_json(void)
     {
         char *delimiter = i < ctx.num_devices - 1 ? "," : "";
         printf(
-            "  {\"name\: \"%s\", \"vram\": \"%s\", \"arch\": \"%s\", \"dev_id\": \"0x%04x\", \"pci_id\": \"%02x:%02x:%02x\", \"temp\": %d}%s\n",
+            "  {\"name\": \"%s\", \"vram\": \"%s\", \"arch\": \"%s\", \"dev_id\": \"0x%04x\", \"pci_id\": \"%02x:%02x:%02x\", \"temp\": %d}%s\n",
             ctx.devices[i].name, ctx.devices[i].vram, ctx.devices[i].arch, ctx.devices[i].dev_id, ctx.devices[i].bus, ctx.devices[i].dev,
-            ctx.devices[i].func, ctx.temperatures[i]
+            ctx.devices[i].func, ctx.temperatures[i], delimiter
         );
     }
     printf("]\n");

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -109,7 +109,7 @@ int gddr6_detect_compatible_gpus(void)
     return ctx.num_devices;
 }
 
-void gddr6_memory_map(int verbose)
+void gddr6_memory_map()
 {
     for (uint32_t i = 0; i < ctx.num_devices; i++)
     {
@@ -124,12 +124,19 @@ void gddr6_memory_map(int verbose)
             fprintf(stderr, "Did you enable iomem=relaxed? Are you r00t?\n");
             exit(EXIT_FAILURE);
         }
+    }
+}
 
-        if (verbose)
-        {
-            printf("Device: %s %s (%s / 0x%04x) pci=%02X:%02X.%X\n", ctx.devices[i].name, ctx.devices[i].vram,
-            ctx.devices[i].arch, ctx.devices[i].dev_id, ctx.devices[i].bus, ctx.devices[i].dev, ctx.devices[i].func);
+void gddr6_print_memory_map()
+{
+    for (uint32_t i = 0; i < ctx.num_devices; i++)
+    {
+        if (ctx.devices[i].mapped_addr == NULL || ctx.devices[i].mapped_addr == MAP_FAILED) {
+            continue;
         }
+
+        printf("Device: %s %s (%s / 0x%04x) pci=%02X:%02X.%X\n", ctx.devices[i].name, ctx.devices[i].vram,
+            ctx.devices[i].arch, ctx.devices[i].dev_id, ctx.devices[i].bus, ctx.devices[i].dev, ctx.devices[i].func);
     }
 }
 

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -181,7 +181,7 @@ void gddr6_print_temperatures_json(void)
     {
         char *delimiter = i < ctx.num_devices - 1 ? "," : "";
         printf(
-            "  {\"name\": \"%s\", \"vram\": \"%s\", \"arch\": \"%s\", \"dev_id\": \"0x%04x\", \"pci_id\": \"%02X:%02X:%X\", \"temp\": %d}%s\n",
+            "  {\"name\": \"%s\", \"vram\": \"%s\", \"arch\": \"%s\", \"dev_id\": \"0x%04x\", \"pci_id\": \"%02X:%02X.%X\", \"temp\": %d}%s\n",
             ctx.devices[i].name, ctx.devices[i].vram, ctx.devices[i].arch, ctx.devices[i].dev_id, ctx.devices[i].bus, ctx.devices[i].dev,
             ctx.devices[i].func, ctx.temperatures[i], delimiter
         );

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -109,7 +109,7 @@ int gddr6_detect_compatible_gpus(void)
     return ctx.num_devices;
 }
 
-void gddr6_memory_map()
+void gddr6_memory_map(void)
 {
     for (uint32_t i = 0; i < ctx.num_devices; i++)
     {
@@ -127,7 +127,7 @@ void gddr6_memory_map()
     }
 }
 
-void gddr6_print_memory_map()
+void gddr6_print_memory_map(void)
 {
     for (uint32_t i = 0; i < ctx.num_devices; i++)
     {
@@ -160,6 +160,8 @@ void gddr6_get_temperatures(void)
 
 void gddr6_monitor_temperatures(void)
 {
+    gddr6_print_memory_map();
+
     while (1)
     {
         gddr6_get_temperatures();

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -139,7 +139,7 @@ void gddr6_get_temperatures(void)
     {
         if (ctx.devices[i].mapped_addr == NULL || ctx.devices[i].mapped_addr == MAP_FAILED)
         {
-            ctx.temperatures[i] = 0;;
+            ctx.temperatures[i] = 0;
         }
         else
         {

--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -100,7 +100,7 @@ int gddr6_detect_compatible_gpus(void)
 
     pci_cleanup(pacc);
 
-    ctx.temperatures = malloc(ctx.num_devices * sizeof(uint32_t));
+    ctx.temperatures = malloc(ctx.num_devices * sizeof(int32_t));
     if (ctx.temperatures == NULL)
     {
         fprintf(stderr, "Memory allocation failed\n");
@@ -153,7 +153,7 @@ void gddr6_get_temperatures(void)
         {
             void *virt_addr = (uint8_t *) ctx.devices[i].mapped_addr + (ctx.devices[i].phys_addr  - ctx.devices[i].base_offset);
             uint32_t read_result = *((uint32_t *)virt_addr);
-            uint32_t temp = ((read_result & 0x00000fff) / 0x20);
+            int8_t temp = (read_result & 0x00001fff) >> 5;
             ctx.temperatures[i] = temp;
         }
     }
@@ -169,7 +169,7 @@ void gddr6_monitor_temperatures(void)
         printf("\rVRAM Temps: |");
         for (uint32_t i = 0; i < ctx.num_devices; i++)
         {
-            printf(" %3u°C |", ctx.temperatures[i]);
+            printf(" %3d°C |", ctx.temperatures[i]);
         }
         fflush(stdout);
         sleep(1);


### PR DESCRIPTION
Hi Ole.

This suggested change adds a "-j" CLI arg which prints the data in JSON format and exits. 
It should not break the existing ABI of libgddr6.
It also changes the display of PCI IDs to match the format used by nvidia-smi (02:00.0).