### PR TITLE
Update gddr6.c to add RTX 4090 D

### DIFF
--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -26,6 +26,7 @@ struct gddr6_ctx ctx = {0};
 struct device dev_table[] =
 {
     { .offset = 0x0000E2A8, .dev_id = 0x2684, .vram = "GDDR6X", .arch = "AD102", .name =  "RTX 4090" },
+    { .offset = 0x0000E2A8, .dev_id = 0x2685, .vram = "GDDR6X", .arch = "AD102", .name =  "RTX 4090 D" },
     { .offset = 0x0000E2A8, .dev_id = 0x2702, .vram = "GDDR6X", .arch = "AD103", .name =  "RTX 4080 Super" },
     { .offset = 0x0000E2A8, .dev_id = 0x2704, .vram = "GDDR6X", .arch = "AD103", .name =  "RTX 4080" },
     { .offset = 0x0000E2A8, .dev_id = 0x2705, .vram = "GDDR6X", .arch = "AD103", .name =  "RTX 4070 Ti Super" },


### PR DESCRIPTION
Add device id of RTX 4090 D to gddr6.c, tested on real hardware:

![image](https://github.com/user-attachments/assets/d6f8211d-06ef-4b3a-93ba-667ab0498fdb)
