### PR TITLE
Support temperatures < 0

### DIFF
--- a/lib/src/gddr6.c
+++ b/lib/src/gddr6.c
@@ -138,9 +138,9 @@ void gddr6_monitor_temperatures(void)
 
             void *virt_addr = (uint8_t *) ctx.devices[i].mapped_addr + (ctx.devices[i].phys_addr  - ctx.devices[i].base_offset);
             uint32_t read_result = *((uint32_t *)virt_addr);
-            uint32_t temp = ((read_result & 0x00000fff) / 0x20);
+            int8_t temp = (read_result & 0x00001fff) >> 5;
 
-            printf(" %3u°C |", temp);
+            printf(" %3d°C |", (int32_t)temp);
         }
         fflush(stdout);
         sleep(1);


### PR DESCRIPTION
The code was modified to to extract 13-bit signed value instead of 12-bit unsigned.

The type cast from `int8_t` to `int32_t` allows for proper sign extension.

Verified on RTX 4090:
```
Device: RTX 4090 GDDR6X (AD102 / 0x2684) pci=7:0:0
Device: RTX 4090 GDDR6X (AD102 / 0x2684) pci=1:0:0
Device: RTX 4090 GDDR6X (AD102 / 0x2684) pci=2:0:0
Device: RTX 4090 GDDR6X (AD102 / 0x2684) pci=3:0:0
VRAM Temps: |   0°C |   4°C |   2°C |  -2°C
```